### PR TITLE
Refactor installation of vBase in samples and requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/validityBase/vbase-py.git#egg=vbase
+vbase
 google
 
 

--- a/samples/add_string_dataset_record.ipynb
+++ b/samples/add_string_dataset_record.ipynb
@@ -24,7 +24,7 @@
     "%%capture\n",
     "\n",
     "# Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "    \n",
     "import pprint\n",

--- a/samples/add_string_dataset_record_async.ipynb
+++ b/samples/add_string_dataset_record_async.ipynb
@@ -26,7 +26,7 @@
     "%%capture\n",
     "\n",
     "# Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "    \n",
     "import pprint\n",

--- a/samples/create_set.ipynb
+++ b/samples/create_set.ipynb
@@ -17,7 +17,7 @@
     "%%capture\n",
     "\n",
     "# Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "    \n",
     "import pprint\n",

--- a/samples/produce_portfolio_history_s3.ipynb
+++ b/samples/produce_portfolio_history_s3.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "#  Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!pip install boto3\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples/main/samples/aws_utils.py\n",

--- a/samples/produce_sentiment_dataset_history_s3.ipynb
+++ b/samples/produce_sentiment_dataset_history_s3.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "#  Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!pip install boto3\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples/main/samples/aws_utils.py\n",

--- a/samples/verify_portfolio_history_s3.ipynb
+++ b/samples/verify_portfolio_history_s3.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "#  Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!pip install boto3\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples/main/samples/aws_utils.py\n",

--- a/samples/verify_sentiment_dataset_history_s3.ipynb
+++ b/samples/verify_sentiment_dataset_history_s3.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "#  Install vBase requirements.\n",
-    "!pip install git+https://github.com/validityBase/vbase-py.git\n",
+    "!pip install vbase\n",
     "!pip install boto3\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples-collab/main/samples/collab_utils.py\n",
     "!wget --no-clobber https://raw.githubusercontent.com/validityBase/vbase-py-samples/main/samples/aws_utils.py\n",


### PR DESCRIPTION
- Updated requirements.txt to install vBase directly instead of from GitHub.
- Modified Jupyter notebooks to install vBase from PyPI instead of GitHub repository.
- Ensured consistency across all sample notebooks for vBase installation.